### PR TITLE
test: feature pipeline parity + schema validation

### DIFF
--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,55 @@
+import numpy as np
+import pandas as pd
+from common.features import build_features, prepare_training, TYPE_CATS
+
+def _mk_rows(types):
+    rows = []
+    for i, t in enumerate(types, start=1):
+        rows.append({
+            "step": i, "type": t, "amount": 1000.0 * i,
+            "nameOrig": f"C{i}", "oldbalanceOrg": 5000.0 * i, "newbalanceOrig": 4000.0 * i,
+            "nameDest": f"M{i}", "oldbalanceDest": 1000.0 * i, "newbalanceDest": 1500.0 * i,
+            "isFlaggedFraud": 0, "isFraud": int(i % 2 == 0),
+        })
+    return pd.DataFrame(rows)
+
+def test_build_features():
+    df = _mk_rows(["PAYMENT"])
+    X = build_features(df, for_inference=True)
+
+    # one-hot columns for ALL categories must exist (even if zeros)
+    for cat in TYPE_CATS:
+        assert f"type_{cat}" in X.columns
+
+    # engineered columns exist
+    for col in ["log_amount", "deltaOrig", "deltaDest", "abs_errorOrig", "abs_errorDest", "hour", "day", "is_high_value"]:
+        assert col in X.columns
+
+    # raw balance columns and amount should be dropped
+    for col in ["oldbalanceOrg", "newbalanceOrig", "oldbalanceDest", "newbalanceDest", "amount", "errorOrig", "errorDest"]:
+        assert col not in X.columns
+
+    # label should not be present at inference
+    assert "isFraud" not in X.columns
+
+    # quick value sanity checks
+    assert np.isclose(X.loc[0, "log_amount"], np.log1p(1000.0))
+    assert X.loc[0, "hour"] == df.loc[0, "step"] % 24
+    assert X.loc[0, "day"] == df.loc[0, "step"] // 24
+
+def test_training_features():
+    # Train sees some types; validation sees a different subset
+    df_tr = _mk_rows(["PAYMENT", "TRANSFER", "CASH_OUT", "PAYMENT"])
+    Xtr, ytr, feature_order = prepare_training(df_tr)
+
+    # Inference batch with missing categories (e.g., DEBIT, CASH_IN only)
+    df_va = _mk_rows(["DEBIT", "CASH_IN"]).drop(columns=["isFraud"])
+    Xva = build_features(df_va, for_inference=True).reindex(columns=feature_order, fill_value=0)
+
+    # Columns align 1:1 with the saved training feature order
+    assert Xtr.columns.tolist() == feature_order
+    assert Xva.columns.tolist() == feature_order
+
+    # Reindexing fills missing categories with zeros
+    type_cols = [c for c in feature_order if c.startswith("type_")]
+    assert (Xva[type_cols].isin([0, 1]).all().all())

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,18 @@
+import importlib
+import pandas as pd
+import pytest
+
+pa = importlib.util.find_spec("pandera")
+pytestmark = pytest.mark.skipif(pa is None, reason="Pandera not installed")
+
+from common.schemas import TrainingSchema
+
+def test_training_schema():
+    df = pd.DataFrame([{
+        "step": 1, "type": "PAYMENT", "amount": 100.0,
+        "nameOrig": "C1", "oldbalanceOrg": 500.0, "newbalanceOrig": 400.0,
+        "nameDest": "M1", "oldbalanceDest": 100.0, "newbalanceDest": 200.0,
+        "isFlaggedFraud": 0, "isFraud": 0,
+    }])
+    out = TrainingSchema.validate(df)  # should not raise
+    assert len(out) == 1


### PR DESCRIPTION
## Summary
Centralizes feature engineering and data contracts to prevent train/serve skew, and adds tests to lock behavior.

## Changes
- `common/features.py`: deterministic pipeline (OHE `type`, `log1p(amount)`, deltas/errors, `hour/day`, `is_high_value`) + `prepare_training()` returning `feature_order`.
- `common/schemas.py`: Pydantic `TransactionRequest` + Pandera `TrainingSchema`/`InferenceSchema`.
- Tests: `tests/test_features.py`, `tests/test_schemas.py` (schema test auto-skips if Pandera missing).
- Pytest configured to import repo modules.

## Verification
- Ran locally: `PYTHONPATH=. pytest -q` → all tests pass.

## Notes
- No runtime behavior change to existing training yet.

## Next
- Switch training to `prepare_training()` and log `feature_order.json`.
- Export `feature_order.json` with the model to S3 for Lambda parity.
