### PR TITLE
data: add DVC stage to split paysim_clean.csv into train/valid/test 

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -1,0 +1,31 @@
+schema: '2.0'
+stages:
+  split_data:
+    cmd: python scripts/split_data.py --input data/processed/paysim_clean.csv 
+      --method time --train 0.70 --valid 0.15 --test 0.15
+    deps:
+    - path: data/processed/paysim_clean.csv
+      hash: md5
+      md5: 2e19fe13f38bcbf7f5c71f4dd4a7704c
+      size: 348997220
+    - path: scripts/split_data.py
+      hash: md5
+      md5: 4d89ced32306b986cf8942b5bbb3d920
+      size: 2863
+    outs:
+    - path: data/processed/split_stats.csv
+      hash: md5
+      md5: 1fe5800072df406bca83c548e8d5a68a
+      size: 183
+    - path: data/processed/test.csv
+      hash: md5
+      md5: 1ad097bbff9ae32ee6ade21591176328
+      size: 52514400
+    - path: data/processed/train.csv
+      hash: md5
+      md5: 6a1b765fe4218ea0673248d128cf5b2f
+      size: 243977525
+    - path: data/processed/valid.csv
+      hash: md5
+      md5: d95137db1e1cd006b1dffb7edb98b665
+      size: 52505441

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -1,0 +1,14 @@
+stages:
+  split_data:
+    cmd: python scripts/split_data.py --input data/processed/paysim_clean.csv 
+      --method time --train 0.70 --valid 0.15 --test 0.15
+    deps:
+    - data/processed/paysim_clean.csv
+    - scripts/split_data.py
+    outs:
+    - data/processed/test.csv
+    - data/processed/train.csv
+    - data/processed/valid.csv
+    metrics:
+    - data/processed/split_stats.csv:
+        cache: false

--- a/scripts/split_data.py
+++ b/scripts/split_data.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+import argparse
+from pathlib import Path
+import pandas as pd
+import numpy as np
+
+def split_time(df, label_col, step_col, train, valid, test, seed=42, shuffle_within=False):
+    df = df.sort_values(step_col).reset_index(drop=True)
+    n = len(df)
+    n_train = int(n * train)
+    n_valid = int(n * valid)
+    tr = df.iloc[:n_train]
+    va = df.iloc[n_train:n_train+n_valid]
+    te = df.iloc[n_train+n_valid:]
+    if shuffle_within:
+        tr = tr.sample(frac=1, random_state=seed)
+        va = va.sample(frac=1, random_state=seed)
+        te = te.sample(frac=1, random_state=seed)
+    return tr, va, te
+
+def split_stratified(df, label_col, train, valid, test, seed=42):
+    from sklearn.model_selection import train_test_split
+    tr, tmp = train_test_split(df, test_size=1-train, stratify=df[label_col], random_state=seed)
+    rel = valid / (valid + test)
+    va, te = train_test_split(tmp, test_size=1-rel, stratify=tmp[label_col], random_state=seed)
+    return tr, va, te
+
+def stats(df, label_col, step_col, name):
+    n = len(df)
+    pos = int(df[label_col].sum()) if label_col in df.columns else 0
+    rate = float(pos) / n if n else 0.0
+    return dict(split=name, rows=int(n), positives=pos, rate=rate,
+                min_step=int(df[step_col].min()), max_step=int(df[step_col].max()))
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", default="data/processed/paysim_clean.csv")
+    ap.add_argument("--out-dir", default="data/processed")
+    ap.add_argument("--label-col", default="isFraud")
+    ap.add_argument("--step-col", default="step")
+    ap.add_argument("--method", choices=["time","stratified"], default="time")
+    ap.add_argument("--train", type=float, default=0.70)
+    ap.add_argument("--valid", type=float, default=0.15)
+    ap.add_argument("--test",  type=float, default=0.15)
+    ap.add_argument("--seed", type=int, default=42)
+    args = ap.parse_args()
+    assert abs(args.train + args.valid + args.test - 1.0) < 1e-6, "fractions must sum to 1"
+
+    df = pd.read_csv(args.input)
+    if args.method == "time":
+        tr, va, te = split_time(df, args.label_col, args.step_col, args.train, args.valid, args.test, seed=args.seed)
+    else:
+        tr, va, te = split_stratified(df, args.label_col, args.train, args.valid, args.test, seed=args.seed)
+
+    out = Path(args.out_dir); out.mkdir(parents=True, exist_ok=True)
+    tr.to_csv(out/"train.csv", index=False)
+    va.to_csv(out/"valid.csv", index=False)
+    te.to_csv(out/"test.csv",  index=False)
+
+    rep = pd.DataFrame([
+        stats(tr, args.label_col, args.step_col, "train"),
+        stats(va, args.label_col, args.step_col, "valid"),
+        stats(te, args.label_col, args.step_col, "test"),
+    ])
+    rep.to_csv(out/"split_stats.csv", index=False)
+    print(rep.to_string(index=False))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Add reproducible **time-based** data split for PaySim using **DVC**. Produces `train/`, `valid/`, `test/` from `paysim_clean.csv` and logs split stats as a metric.

## Changes
- `scripts/split_data.py`: split by chronological `step` (default 70/15/15), optional stratified mode.
- `dvc.yaml` + `dvc.lock`: new `split_data` stage with outputs:
  - `data/processed/train.csv`, `valid.csv`, `test.csv`
  - Metrics: `data/processed/split_stats.csv`

## Why
- Prevent temporal leakage (train earlier → validate/test later).
- Make splits fully reproducible and shareable via DVC.
- Keep `test.csv` untouched for the Streamlit “simulate” demo.

## How to run
```bash
dvc repro          # generates train/valid/test + split_stats
dvc metrics show   # view split summary
```

## Notes
* Source: `data/processed/paysim_clean.csv `(DVC-tracked).
* Push code + metadata with `git push`, and data with `dvc push`.