### PR TITLE
MLflow remote tracking + XGBoost training pipeline (S3-backed)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,14 @@
-# MLflow
-MLFLOW_TRACKING_URI=http://localhost:5000
-MLFLOW_S3_ENDPOINT_URL=https://s3.amazonaws.com
+# ---- AWS (for S3 artifacts) ----
+AWS_ACCESS_KEY_ID=YOUR_KEY
+AWS_SECRET_ACCESS_KEY=YOUR_SECRET
+AWS_DEFAULT_REGION=us-east-1
 
-AWS_ACCESS_KEY_ID=your-aws-key-here
-AWS_SECRET_ACCESS_KEY=your-aws-secret-here
+# ---- MLflow ----
+ARTIFACTS_URI=s3://your-bucket/your-prefix
 
-MLFLOW_ARTIFACT_URI=s3://your-bucket-name/mlflow/
+# Optional: choose a host port if 5500 is used
+MLFLOW_HOST_PORT=5500
 
-# FastAPI
-API_HOST=0.0.0.0
-API_PORT=8000
-
-# AWS or DB credentials can be added later
+# Project scoping
+PROJECT_SLUG=fraud
+ENV_SLUG=prod

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,14 @@ src/*.egg-info/
 build/
 dist/
 
+# docker volumes / local state
+postgres-data/
+minio-data/
+mlflow/
+mlflow_s3/
+**/mlruns/
+**/mlflow.db
+
 # Jupyter
 *.ipynb_checkpoints
 .virtual_documents/
@@ -58,3 +66,4 @@ Thumbs.db
 
 # Misc
 TREE.txt
+eval_snapshot.json

--- a/best_xgb_params.json
+++ b/best_xgb_params.json
@@ -1,0 +1,1 @@
+{"colsample_bytree": 0.877278091860128, "gamma": 0.0007412820161393726, "learning_rate": 0.012951232741934696, "max_depth": 4, "min_child_weight": 1.1305546123305603, "n_estimators": 1200, "subsample": 0.7356029819453461}

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,75 @@
+services:
+  # --- PostgreSQL ---
+  postgres:
+    image: postgres:17
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: mlflowdb
+    ports: ["5432:5432"]
+    volumes: ["./postgres-data:/var/lib/postgresql/data"]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U user -d mlflowdb"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # --- MinIO (S3-compatible) ---
+  minio:
+    image: minio/minio:latest
+    ports:
+      - "9000:9000"   # S3 API
+      - "9001:9001"   # Console
+    environment:
+      MINIO_ROOT_USER: "minio_user"
+      MINIO_ROOT_PASSWORD: "minio_password"
+    command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD-SHELL", "timeout 5s bash -lc ':> /dev/tcp/127.0.0.1/9000' || exit 1"]
+      interval: 2s
+      timeout: 10s
+      retries: 20
+    profiles: ["dev"]
+
+  # Create bucket if missing
+  minio-create-bucket:
+    image: minio/mc
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      bash -lc "
+      mc alias set minio http://minio:9000 minio_user minio_password &&
+      mc ls minio/mlops-fraud-dvc || mc mb minio/mlops-fraud-dvc
+      "
+    profiles: ["dev"]
+
+  # --- MLflow Tracking Server ---
+  mlflow:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM ghcr.io/mlflow/mlflow:v3.1.4
+        RUN pip install --no-cache-dir psycopg2-binary==2.9.9 boto3==1.34.162
+    container_name: mlflow-server
+    depends_on:
+      postgres:
+        condition: service_healthy
+      # minio:
+      #   condition: service_healthy
+      # minio-create-bucket:
+      #   condition: service_completed_successfully
+    ports:
+      - "5500:5000"   # host:container
+    environment:
+      # MLFLOW_S3_ENDPOINT_URL: http://minio:9000
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}
+      # MLFLOW_ENABLE_SYSTEM_METRICS: "true"
+    command: >
+      mlflow server
+        --host 0.0.0.0 --port 5000
+        --backend-store-uri postgresql+psycopg2://user:password@postgres:5432/mlflowdb
+        --artifacts-destination ${ARTIFACTS_URI}
+        --serve-artifacts

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ hyperopt	# Distributed hyperparameter turing (works with MLflow)
 
 # === Experiment Tracking ===
 mlflow		# Track and compare model runs, params, metrics
-
+psycopg2-binary  # PostgreSQL driver for MLflow tracking server
 # === AWS Integration ===
 boto3                   # Required for AWS S3 access (used by DVC and MLflow)
 awscli                  # AWS CLI for S3 config & DVC remote access

--- a/training/hyperopt/search_xgb.py
+++ b/training/hyperopt/search_xgb.py
@@ -1,0 +1,115 @@
+# training/pipelines/train_xgb.py
+from __future__ import annotations
+import os, json, sys, logging
+import pandas as pd
+import mlflow, xgboost as xgb
+from sklearn.metrics import average_precision_score, roc_auc_score
+from mlflow.models import infer_signature
+from mlflow.tracking import MlflowClient
+from mlops_fraud.features import prepare_training, build_features
+try:
+    from mlops_fraud.schemas import TrainingSchema
+except Exception:
+    TrainingSchema = None
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+log = logging.getLogger(__name__)
+
+# ---- Config (match search_xgb.py) ----
+TRACKING = os.getenv("MLFLOW_TRACKING_URI", "http://localhost:5500")
+EXP_NAME = os.getenv("MLFLOW_EXPERIMENT", "fraud_tuning_v2")   # same default as search
+ARTIFACTS_URI = os.getenv("ARTIFACTS_URI", "").rstrip("/")
+EXP_ARTIFACT_DIR = os.getenv("EXP_ARTIFACT_DIR", EXP_NAME)
+
+MODEL_NAME = os.getenv("MLFLOW_MODEL_NAME", "fraud_xgb")
+TRAIN_PATH = os.getenv("TRAIN_PATH", "data/processed/train.csv")
+VALID_PATH = os.getenv("VALID_PATH", "data/processed/valid.csv")
+RUN_NAME   = os.getenv("RUN_NAME", "xgb_final")
+LABEL      = os.getenv("LABEL_COL", "isFraud")  # ≤ keep consistent with search
+BEST_PARAMS_JSON = os.getenv("BEST_PARAMS_JSON", "best_xgb_params.json")
+
+def _ensure_experiment(name: str) -> str:
+    """Create experiment with S3 artifact root like s3://<bucket>/artifacts/<EXP_ARTIFACT_DIR>."""
+    client = MlflowClient()
+    exp = client.get_experiment_by_name(name)
+    if exp:
+        return exp.experiment_id
+    artifact_location = f"{ARTIFACTS_URI}/{EXP_ARTIFACT_DIR}" if ARTIFACTS_URI else None
+    return client.create_experiment(name, artifact_location=artifact_location)
+
+def _load_csv(path: str) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    if TrainingSchema is not None and LABEL in df.columns:
+        try:
+            TrainingSchema.validate(df)
+        except Exception as e:
+            log.warning(f"schema validation failed for {path}: {e}")
+    return df
+
+def main():
+    # ---- MLflow wiring ----
+    mlflow.set_tracking_uri(TRACKING)
+    exp_id = _ensure_experiment(EXP_NAME)
+    mlflow.set_experiment(EXP_NAME)
+
+    # ---- Data ----
+    log.info(f"Loading train: {TRAIN_PATH}")
+    df_tr = _load_csv(TRAIN_PATH)
+    log.info(f"Loading valid: {VALID_PATH}")
+    df_va = _load_csv(VALID_PATH)
+
+    Xtr, ytr, feature_order = prepare_training(df_tr, label_col=LABEL)
+    yva = df_va[LABEL].astype(int)
+    Xva = build_features(df_va.drop(columns=[LABEL]), for_inference=False).reindex(columns=feature_order, fill_value=0)
+
+    # ---- Params (use best if present) ----
+    params = dict(
+        max_depth=6, learning_rate=0.1, subsample=0.8, colsample_bytree=0.8,
+        objective="binary:logistic", eval_metric="aucpr",
+        n_estimators=400, tree_method="hist",
+    )
+    if os.path.exists(BEST_PARAMS_JSON):
+        log.info(f"Loading best params from {BEST_PARAMS_JSON}")
+        with open(BEST_PARAMS_JSON) as f:
+            best = json.load(f)
+        # coerce integer params
+        for k in ("max_depth", "n_estimators"):
+            if k in best: best[k] = int(best[k])
+        params.update(best)
+
+    # ---- Train + log ----
+    with mlflow.start_run(run_name=RUN_NAME):
+        run_id = mlflow.active_run().info.run_id
+        log.info(f"Experiment ID: {exp_id} | Run ID: {run_id}")
+
+        mlflow.log_params(params)
+        clf = xgb.XGBClassifier(**params)
+        clf.fit(Xtr, ytr, eval_set=[(Xva, yva)], verbose=False)
+
+        p = clf.predict_proba(Xva)[:, 1]
+        pr_auc = float(average_precision_score(yva, p))
+        roc    = float(roc_auc_score(yva, p))
+        mlflow.log_metric("pr_auc", pr_auc)
+        mlflow.log_metric("roc_auc", roc)
+        log.info(f"PR AUC: {pr_auc:.4f} | ROC AUC: {roc:.4f}")
+
+        # Signature ensures correct input schema at load/serve time
+        sig = infer_signature(Xva, p)
+        mlflow.xgboost.log_model(
+            xgb_model=clf,
+            artifact_path="model",
+            signature=sig,
+            registered_model_name=MODEL_NAME,  # optional registry
+        )
+
+        mlflow.log_text(json.dumps(feature_order), "feature_order.json")
+        mlflow.log_dict({"pr_auc": pr_auc, "roc_auc": roc}, "metrics.json")
+
+    print(f"[done] Run: {run_id} | PR-AUC={pr_auc:.4f} ROC-AUC={roc:.4f}")
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        import traceback; traceback.print_exc()
+        sys.exit(1)

--- a/training/hyperopt/smoke_mlflow.py
+++ b/training/hyperopt/smoke_mlflow.py
@@ -1,0 +1,61 @@
+# training/hyperopt/smoke_mlflow.py
+from __future__ import annotations
+import os, json, mlflow
+from mlflow.tracking import MlflowClient
+from sklearn.datasets import make_classification
+from sklearn.model_selection import train_test_split
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import accuracy_score
+import random
+
+TRACKING = os.getenv("MLFLOW_TRACKING_URI", "http://localhost:5500")
+EXP_NAME = os.getenv("MLFLOW_EXPERIMENT", "smoke_fast")
+ARTIFACTS_URI = os.getenv("ARTIFACTS_URI", "").rstrip("/")
+EXP_ARTIFACT_DIR = os.getenv("EXP_ARTIFACT_DIR", EXP_NAME)
+
+def ensure_experiment(name: str) -> str:
+    client = MlflowClient()
+    exp = client.get_experiment_by_name(name)
+    if exp:
+        return exp.experiment_id
+    artifact_location = f"{ARTIFACTS_URI}/{EXP_ARTIFACT_DIR}" if ARTIFACTS_URI else None
+    return client.create_experiment(name, artifact_location=artifact_location)
+
+def main():
+    mlflow.set_tracking_uri(TRACKING)
+    exp_id = ensure_experiment(EXP_NAME)
+    mlflow.set_experiment(EXP_NAME)  # binds following runs to this experiment
+
+    # tiny dataset so it’s instant
+    X, y = make_classification(n_samples=200, n_features=10, n_informative=5, random_state=42)
+    Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.25, random_state=42)
+
+    with mlflow.start_run(run_name="smoke"):
+        # train a super-fast model
+        model = LogisticRegression(max_iter=200, n_jobs=1)
+        model.fit(Xtr, ytr)
+        acc = accuracy_score(yte, model.predict(Xte))
+
+        # log basics
+        mlflow.log_param("algo", "logreg")
+        mlflow.log_metric("accuracy", float(acc))
+        mlflow.sklearn.log_model(model, "model")  # saved under the run's artifacts
+
+        # log a tiny artifact
+        with open("summary.json", "w") as f:
+            json.dump({"accuracy": float(acc)}, f)
+        mlflow.log_artifact("summary.json")
+
+        # a couple of nested "trials" to mimic hyperopt structure
+        for depth in [2, 3, 4]:
+            with mlflow.start_run(run_name=f"trial_depth={depth}", nested=True):
+                mlflow.log_param("depth", depth)
+                mlflow.log_metric("score", random.random())
+
+        run_id = mlflow.active_run().info.run_id
+
+    print(f"Run: {run_id}")
+    print(f"UI:  {TRACKING}/#/experiments/{exp_id}/runs/{run_id}")
+
+if __name__ == "__main__":
+    main()

--- a/training/pipelines/evaluate.py
+++ b/training/pipelines/evaluate.py
@@ -1,0 +1,24 @@
+# training/pipelines/evaluate.py
+from __future__ import annotations
+import os, json
+import pandas as pd
+from sklearn.metrics import precision_recall_curve
+from mlops_fraud.features import build_features
+
+LABEL = os.getenv("LABEL_COL", "isFraud")
+VALID_PATH = os.getenv("VALID_PATH", "data/processed/valid.csv")
+FEATURE_ORDER_PATH = os.getenv("FEATURE_ORDER_PATH", "")  # optional path to feature_order.json
+
+def main():
+    df = pd.read_csv(VALID_PATH)
+    y = df[LABEL].astype(int)
+    X = build_features(df.drop(columns=[LABEL]), for_inference=False)
+
+    # Placeholder: save feature schema snapshot for debugging.
+    snap = {"columns": X.columns.tolist(), "n_rows": int(X.shape[0])}
+    with open("eval_snapshot.json", "w") as f:
+        json.dump(snap, f)
+    print("[eval] wrote eval_snapshot.json")
+
+if __name__ == "__main__":
+    main()

--- a/training/pipelines/train_xgb.py
+++ b/training/pipelines/train_xgb.py
@@ -1,0 +1,125 @@
+# training/pipelines/train_xgb.py
+from __future__ import annotations
+import os, json, sys, logging
+import pandas as pd
+import mlflow
+import xgboost as xgb
+from sklearn.metrics import average_precision_score, roc_auc_score
+from mlflow.models import infer_signature
+from mlflow.tracking import MlflowClient
+from mlops_fraud.features import prepare_training, build_features
+try:
+    from mlops_fraud.schemas import TrainingSchema
+except Exception:
+    TrainingSchema = None
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+# ---- Config (env) ----
+MLFLOW_TRACKING_URI = os.getenv("MLFLOW_TRACKING_URI", "http://localhost:5500")
+EXP_NAME = os.getenv("MLFLOW_EXPERIMENT", "fraud_train")          # experiment name
+EXP_ARTIFACT_DIR = os.getenv("EXP_ARTIFACT_DIR", EXP_NAME)        # subfolder under artifacts/
+MODEL_NAME = os.getenv("MODEL_NAME", "fraud_xgb")
+TRAIN_PATH = os.getenv("TRAIN_PATH", "data/processed/train.csv")
+VALID_PATH = os.getenv("VALID_PATH", "data/processed/valid.csv")
+RUN_NAME = os.getenv("RUN_NAME", "xgb_final")
+LABEL = os.getenv("LABEL_COL", "isFraud")                        # ensure it matches your data
+BEST_PARAMS_JSON = os.getenv("BEST_PARAMS_JSON", "best_xgb_params.json")
+
+def _ensure_experiment(name: str) -> str:
+    """
+    Create the experiment with an artifact root routed via the MLflow artifact proxy:
+      mlflow-artifacts:/artifacts/<EXP_ARTIFACT_DIR>
+    The tracking server maps this to your S3 bucket/prefix (ARTIFACTS_URI).
+    """
+    client = MlflowClient()
+    exp = client.get_experiment_by_name(name)
+    if exp:
+        return exp.experiment_id
+    artifact_location = f"mlflow-artifacts:/artifacts/{EXP_ARTIFACT_DIR}"
+    return client.create_experiment(name, artifact_location=artifact_location)
+
+def load_csv(path: str) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    if TrainingSchema is not None and LABEL in df.columns:
+        try:
+            TrainingSchema.validate(df)
+        except Exception as e:
+            logger.warning(f"schema validation failed for {path}: {e}")
+    return df
+
+def main():
+    # ---- Wire MLflow ----
+    logger.info(f"Setting MLflow tracking URI: {MLFLOW_TRACKING_URI}")
+    mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)
+    exp_id = _ensure_experiment(EXP_NAME)
+    mlflow.set_experiment(EXP_NAME)
+
+    # ---- Data ----
+    logger.info(f"Loading train: {TRAIN_PATH}")
+    df_tr = load_csv(TRAIN_PATH)
+    logger.info(f"Loading valid: {VALID_PATH}")
+    df_va = load_csv(VALID_PATH)
+
+    logger.info("Building features")
+    Xtr, ytr, feature_order = prepare_training(df_tr, label_col=LABEL)
+    yva = df_va[LABEL].astype(int)
+    Xva = build_features(df_va.drop(columns=[LABEL]), for_inference=False).reindex(columns=feature_order, fill_value=0)
+
+    # ---- Params (use best if present) ----
+    base_params = dict(
+        max_depth=6, learning_rate=0.1, subsample=0.8, colsample_bytree=0.8,
+        objective="binary:logistic", eval_metric="aucpr", n_estimators=400, tree_method="hist",
+    )
+    if os.path.exists(BEST_PARAMS_JSON):
+        logger.info(f"Loading best params from {BEST_PARAMS_JSON}")
+        with open(BEST_PARAMS_JSON) as f:
+            best = json.load(f)
+        # coerce possible floats to ints for integer params
+        best["max_depth"] = int(best.get("max_depth", base_params["max_depth"]))
+        best["n_estimators"] = int(best.get("n_estimators", base_params["n_estimators"]))
+        params = {**base_params, **best}
+    else:
+        logger.info("best_xgb_params.json not found; using base params")
+        params = base_params
+
+    # ---- Train + log ----
+    with mlflow.start_run(run_name=RUN_NAME):
+        logger.info(f"Experiment ID: {exp_id}  |  Run: {mlflow.active_run().info.run_id}")
+
+        mlflow.log_params(params)
+
+        clf = xgb.XGBClassifier(**params)
+        clf.fit(Xtr, ytr, eval_set=[(Xva, yva)], verbose=False)
+
+        p = clf.predict_proba(Xva)[:, 1]
+        pr_auc = float(average_precision_score(yva, p))
+        roc = float(roc_auc_score(yva, p))
+        logger.info(f"PR AUC: {pr_auc:.4f}  |  ROC AUC: {roc:.4f}")
+
+        mlflow.log_metric("pr_auc", pr_auc)
+        mlflow.log_metric("roc_auc", roc)
+
+        # log model via server proxy (works without client AWS creds)
+        sig = infer_signature(Xva, p)
+        mlflow.xgboost.log_model(
+            xgb_model=clf,
+            artifact_path="model",
+            signature=sig,
+            registered_model_name=MODEL_NAME,   # optional: registers in Model Registry
+        )
+
+        # artifacts: feature order + metrics blob
+        mlflow.log_text(json.dumps(feature_order), "feature_order.json")
+        mlflow.log_dict({"pr_auc": pr_auc, "roc_auc": roc}, "metrics.json")
+
+    print(f"[done] PR-AUC={pr_auc:.4f} ROC-AUC={roc:.4f}")
+
+if __name__ == "__main__":
+    try:
+        main()
+        logger.info("Training completed successfully")
+    except Exception as e:
+        logger.error(f"Training failed: {e}")
+        sys.exit(1)


### PR DESCRIPTION


# MLflow remote tracking + XGBoost training pipeline (S3-backed)

## Summary

This PR wires our project to a **remote MLflow Tracking Server** with **S3 artifact storage**, adds a minimal **infrastructure compose**, and implements an end-to-end **XGBoost training workflow** (hyperopt → train → evaluate). Includes a tiny **smoke test** to validate tracking + artifact proxy.

## What changed

* **Infra**

  * `compose.yaml`: MLflow server (v3.1.4) + Postgres; S3 in prod, MinIO via `--profile dev`.
  * `.env.example`: variables for `MLFLOW_TRACKING_URI`, `ARTIFACTS_URI`, AWS/MinIO.
  * `.gitignore`: ignore local state (e.g., `postgres-data/`, `mlruns/`, env files).
* **Deps**

  * `requirements.txt`: add `psycopg2-binary==2.9.9` (client code if needed; server already installs).
* **Training & Eval**

  * `training/hyperopt/search_xgb.py` – Hyperopt search; creates experiment at `ARTIFACTS_URI/<EXP_ARTIFACT_DIR>`; logs metrics/params + `best_xgb_params.json`.
  * `training/pipelines/train_xgb.py` – Trains final XGB using `best_xgb_params.json` when present; logs metrics; **logs model with signature**; saves `feature_order.json` and `metrics.json`.
  * `training/pipelines/evaluate.py` – Loads model from **Model Registry** (or latest run); reindexes by `feature_order.json`; logs PR/ROC metrics and optional PR curve.
  * `training/hyperopt/smoke_mlflow.py` – Fast smoke test of tracking + artifact proxy.

> All artifacts are written to **S3 via the MLflow server** (`--serve-artifacts`), so clients don’t need AWS creds unless using 3.x “logged models” features.

## How to run

### Start MLflow (S3 prod)

```bash
docker compose --env-file .env.prod up -d
# .env.prod:
# MLFLOW_TRACKING_URI=http://localhost:5500
# ARTIFACTS_URI=s3://<bucket>/artifacts
# AWS_PROFILE=<profile>  # or AK/SK; include AWS_DEFAULT_REGION
```

### Dev (MinIO)

```bash
docker compose --env-file .env.dev --profile dev up -d
# .env.dev includes MLFLOW_S3_ENDPOINT_URL + minio creds
```

### Hyperopt → Train → Evaluate

```bash
export MLFLOW_TRACKING_URI=http://localhost:5500
export ARTIFACTS_URI=s3://<bucket>/artifacts
export MLFLOW_EXPERIMENT=fraud_tuning_v2
export EXP_ARTIFACT_DIR=fraud_tuning_v2
export MLFLOW_MODEL_NAME=fraud_xgb
export LABEL_COL=isFraud

python -m training.hyperopt.search_xgb
python -m training.pipelines.train_xgb
python -m training.pipelines.evaluate
```

## Validation done

* Verified runs appear in MLflow UI, artifacts in `s3://<bucket>/artifacts/<EXP_ARTIFACT_DIR>/…`.
* Confirmed `feature_order.json` present and evaluation reindexes features.
* Smoke test (`training.hyperopt.smoke_mlflow.py`) completes in seconds and logs model + artifacts.
* Ensured client/server MLflow versions match (3.1.4).

## Risks / Notes

* If the MLflow **server version changes**, run DB migration once:

  ```bash
  docker compose run --rm mlflow mlflow db upgrade postgresql+psycopg2://user:password@postgres:5432/mlflowdb
  ```
* Do **not** commit real AWS credentials; use profiles or secrets.
* Existing experiments created before this PR may still write under numeric prefixes (`1/`, `2/`). New experiments use the clean `artifacts/<EXP_ARTIFACT_DIR>/…` layout.

## Checklist

* [ ] `.env.prod` and/or secrets configured in CI/hosting
* [ ] `ARTIFACTS_URI` points to the correct bucket/prefix
* [ ] (Optional) Registered `fraud_xgb` and promoted a version to *Staging/Production*
* [ ] Team aligned to pin **client MLflow** to server version

---
