### PR TITLE
FastAPI Model Serving Integration

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,0 +1,19 @@
+# Dockerfile.api
+FROM python:3.11-slim
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+
+COPY src /app/src
+
+RUN pip install --no-cache-dir \
+    mlflow==3.1.4 fastapi uvicorn[standard] pandas numpy scikit-learn xgboost pydantic boto3
+
+ENV PYTHONPATH=/app/src
+ENV MLFLOW_TRACKING_URI=http://mlflow:5000
+ENV MODEL_NAME=fraud_xgb
+ENV MODEL_ALIAS=staging
+ENV MODEL_REFRESH_SECS=120
+ENV MLFLOW_HTTP_REQUEST_TIMEOUT=30
+
+CMD ["uvicorn", "mlops_fraud.deployment.api:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,3 +1,5 @@
+version: "3.9"
+
 services:
   # --- PostgreSQL ---
   postgres:
@@ -13,8 +15,9 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+    restart: unless-stopped
 
-  # --- MinIO (S3-compatible) ---
+  # --- MinIO (S3-compatible, optional) ---
   minio:
     image: minio/minio:latest
     ports:
@@ -30,8 +33,9 @@ services:
       timeout: 10s
       retries: 20
     profiles: ["dev"]
+    restart: unless-stopped
 
-  # Create bucket if missing
+  # Create bucket if missing (dev only)
   minio-create-bucket:
     image: minio/mc
     depends_on:
@@ -43,6 +47,7 @@ services:
       mc ls minio/mlops-fraud-dvc || mc mb minio/mlops-fraud-dvc
       "
     profiles: ["dev"]
+    restart: "no"
 
   # --- MLflow Tracking Server ---
   mlflow:
@@ -55,21 +60,62 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      # For MinIO dev profile, also depend on these:
       # minio:
       #   condition: service_healthy
       # minio-create-bucket:
       #   condition: service_completed_successfully
     ports:
       - "5500:5000"   # host:container
+    env_file: [.env]
     environment:
+      # For AWS S3 (recommended): leave endpoint UNSET.
+      # For MinIO dev: uncomment next line in your .env or here
       # MLFLOW_S3_ENDPOINT_URL: http://minio:9000
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
       AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}
-      # MLFLOW_ENABLE_SYSTEM_METRICS: "true"
+      AWS_REGION: ${AWS_REGION}
+      ARTIFACTS_URI: ${ARTIFACTS_URI}        # e.g. s3://mlops-fraud-dvc  (no trailing slash)
     command: >
       mlflow server
         --host 0.0.0.0 --port 5000
         --backend-store-uri postgresql+psycopg2://user:password@postgres:5432/mlflowdb
         --artifacts-destination ${ARTIFACTS_URI}
         --serve-artifacts
+    healthcheck:
+      test: ["CMD-SHELL","bash -lc \":> /dev/tcp/127.0.0.1/5000\""]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+    restart: unless-stopped
+
+  # --- FastAPI Inference API ---
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile.api
+    depends_on:
+      mlflow:
+        condition: service_healthy
+    ports:
+      - "8080:8080"
+    env_file: [.env]
+    environment:
+      # Internal MLflow URL (not host port 5500)
+      MLFLOW_TRACKING_URI: http://mlflow:5000
+      MODEL_NAME: ${MODEL_NAME:-fraud_xgb}
+      MODEL_ALIAS: ${MODEL_ALIAS:-staging}
+      MODEL_REFRESH_SECS: ${MODEL_REFRESH_SECS:-120}
+      ARTIFACTS_URI: ${ARTIFACTS_URI}        # used by direct-S3 loader in api.py
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}
+      AWS_REGION: ${AWS_REGION}
+      SKIP_REGISTRY_RESOLVER: "1"          # always go direct to S3
+      MLFLOW_HTTP_REQUEST_TIMEOUT: "5"     # keep small anyway
+      MODEL_READY_TIMEOUT_SECS: "8"
+    restart: unless-stopped
+    # mount optional debug scripts (comment out if not needed)
+    volumes:
+      - ./scripts:/app/scripts:ro

--- a/scripts/smoke_api.py
+++ b/scripts/smoke_api.py
@@ -1,0 +1,41 @@
+# scripts/smoke_api.py
+import os, sys, time, json
+import urllib.request
+
+API = os.getenv("API_BASE", "http://localhost:8080")
+
+def get(path):
+    with urllib.request.urlopen(f"{API}{path}") as r:
+        return r.read().decode()
+
+def post(path, payload):
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(f"{API}{path}", data=data, headers={"Content-Type":"application/json"})
+    with urllib.request.urlopen(req) as r:
+        return r.read().decode()
+
+print("API_BASE:", API)
+
+# 1) healthz (non-blocking)
+print("GET /healthz ->", get("/healthz"))
+
+# 2) readyz (bounded load)
+print("GET /readyz ->", get("/readyz"))
+
+# 3) predict (minimal valid payload)
+sample = {
+  "rows":[
+    {
+      "type":"PAYMENT",
+      "amount":123.45,
+      "step":1,
+      "oldbalanceOrg":1000.0,
+      "newbalanceOrig":876.55,
+      "oldbalanceDest":500.0,
+      "newbalanceDest":623.45
+    }
+  ]
+}
+print("POST /predict ->", post("/predict", sample))
+
+print("SMOKE API: OK")

--- a/scripts/smoke_load.py
+++ b/scripts/smoke_load.py
@@ -1,0 +1,61 @@
+# scripts/smoke_load.py
+import os, tempfile, json
+import mlflow
+from mlflow.tracking import MlflowClient
+
+MODEL_NAME  = os.getenv("MODEL_NAME", "fraud_xgb")
+ALIAS       = os.getenv("MODEL_ALIAS", "staging")
+TRACKING    = os.getenv("MLFLOW_TRACKING_URI", "http://mlflow:5000")
+ART_ROOT    = os.getenv("ARTIFACTS_URI")  # e.g. s3://mlops-fraud-dvc  (no trailing slash)
+
+assert ART_ROOT and ART_ROOT.startswith("s3://"), \
+    "Set ARTIFACTS_URI=s3://<bucket>[/optional-prefix] in env (ex: s3://mlops-fraud-dvc)"
+
+def map_mlflow_artifacts_to_s3(artifacts_uri: str, artifacts_root: str) -> str:
+    """
+    artifacts_uri: 'mlflow-artifacts:/artifacts/<exp>/<run_id>/artifacts'
+    artifacts_root: 's3://bucket' OR 's3://bucket/artifacts'
+    returns: 's3://bucket/artifacts/<exp>/<run_id>/artifacts'
+    (prevents double 'artifacts' when root already ends with /artifacts)
+    """
+    if not artifacts_uri.startswith("mlflow-artifacts:/"):
+        raise ValueError(f"Unexpected artifacts_uri: {artifacts_uri}")
+    tail = artifacts_uri.removeprefix("mlflow-artifacts:/").lstrip("/")   # 'artifacts/...'
+    base = artifacts_root.rstrip("/")
+    if tail.startswith("artifacts/") and base.endswith("/artifacts"):
+        base = base.rsplit("/artifacts", 1)[0]
+    return f"{base}/{tail}"
+
+print("Tracking URI:", TRACKING)
+print("ARTIFACTS_URI:", ART_ROOT)
+mlflow.set_tracking_uri(TRACKING)
+client = MlflowClient()
+
+# Resolve alias -> version
+mv = client.get_model_version_by_alias(MODEL_NAME, ALIAS)
+run = client.get_run(mv.run_id)
+print(f"Model: {MODEL_NAME}  alias: {ALIAS}  -> version: {mv.version}")
+print("run_id:", mv.run_id)
+print("run.info.artifact_uri:", run.info.artifact_uri)
+
+# Map to direct S3 and download the *model* directory
+s3_run_root = map_mlflow_artifacts_to_s3(run.info.artifact_uri, ART_ROOT)
+s3_model_dir = f"{s3_run_root}/model"
+print("Direct S3 model dir:", s3_model_dir)
+
+with tempfile.TemporaryDirectory() as td:
+    local_dir = mlflow.artifacts.download_artifacts(s3_model_dir, dst_path=td)
+    import os as _os
+    print("Downloaded to:", local_dir, "files:", _os.listdir(local_dir))
+
+    # Load flavor (XGB -> PyFunc)
+    try:
+        from mlflow import xgboost as mlf_xgb
+        model = mlf_xgb.load_model(local_dir)
+        print("✅ Loaded XGBoost flavor")
+    except Exception as e1:
+        print("XGBoost failed:", e1, "→ trying PyFunc")
+        model = mlflow.pyfunc.load_model(local_dir)
+        print("✅ Loaded PyFunc flavor")
+
+print("SMOKE LOAD: OK")

--- a/scripts/smoke_predict.py
+++ b/scripts/smoke_predict.py
@@ -1,0 +1,124 @@
+import os, json, tempfile
+import pandas as pd
+import numpy as np
+import mlflow
+from mlflow.tracking import MlflowClient
+import boto3
+
+# ----- Config from env -----
+TRACKING   = os.getenv("MLFLOW_TRACKING_URI", "http://mlflow:5000")
+ART_ROOT   = os.getenv("ARTIFACTS_URI", "").rstrip("/")  # e.g., s3://mlops-fraud-dvc
+MODEL_NAME = os.getenv("MODEL_NAME", "fraud_xgb")
+ALIAS      = os.getenv("MODEL_ALIAS", "staging")
+REGION     = os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION")
+
+assert ART_ROOT.startswith("s3://"), "ARTIFACTS_URI must be s3://<bucket>[/prefix]"
+assert REGION, "Set AWS_REGION or AWS_DEFAULT_REGION"
+
+# ----- Helpers -----
+def map_mlflow_artifacts_to_s3(artifacts_uri: str, artifacts_root: str) -> str:
+    # artifacts_uri looks like: mlflow-artifacts:/artifacts/<exp_name>/<run_id>/artifacts
+    if not artifacts_uri.startswith("mlflow-artifacts:/"):
+        raise ValueError(f"Unexpected artifacts_uri: {artifacts_uri}")
+    tail = artifacts_uri.removeprefix("mlflow-artifacts:/").lstrip("/")
+    base = artifacts_root.rstrip("/")
+    # if both contain '/artifacts', avoid double-joining
+    if tail.startswith("artifacts/") and base.endswith("/artifacts"):
+        base = base[: -len("/artifacts")]
+    return f"{base}/{tail}"
+
+def discover_registry_model_dir(exp_name: str) -> str:
+    """
+    Return s3://.../artifacts/<exp_name>/models/m-*/artifacts (latest by LastModified).
+    """
+    _, rest = ART_ROOT.split("s3://", 1)
+    bucket, *prefix = rest.split("/", 1)
+    base_prefix = (prefix[0] + "/") if prefix else ""
+    models_prefix = f"{base_prefix}artifacts/{exp_name}/models/"
+
+    s3 = boto3.client("s3", region_name=REGION)
+    paginator = s3.get_paginator("list_objects_v2")
+
+    newest_key, newest_time = None, None
+    for page in paginator.paginate(Bucket=bucket, Prefix=models_prefix):
+        for obj in page.get("Contents", []) or []:
+            key = obj["Key"]
+            if key.endswith("artifacts/MLmodel"):
+                lm = obj["LastModified"]
+                if newest_time is None or lm > newest_time:
+                    newest_time, newest_key = lm, key
+    if not newest_key:
+        raise RuntimeError(f"No registry MLmodel under s3://{bucket}/{models_prefix}")
+    return "s3://" + bucket + "/" + newest_key.rsplit("/", 1)[0]  # .../artifacts
+
+# ----- Resolve model, run, and paths -----
+mlflow.set_tracking_uri(TRACKING)
+c = MlflowClient()
+mv  = c.get_model_version_by_alias(MODEL_NAME, ALIAS)
+run = c.get_run(mv.run_id)
+exp = c.get_experiment(run.info.experiment_id)
+
+print(f"Resolved {MODEL_NAME}@{ALIAS} -> v{mv.version}, run_id={mv.run_id}")
+print("run.info.artifact_uri:", run.info.artifact_uri)
+print("experiment:", exp.name)
+
+# Prefer registry folder (works even if mv.source points to a run path)
+s3_model_dir = discover_registry_model_dir(exp.name)
+print("Using model registry dir:", s3_model_dir)
+
+# ----- Download model + feature order -----
+with tempfile.TemporaryDirectory() as td:
+    local_model_dir = mlflow.artifacts.download_artifacts(s3_model_dir, dst_path=td)
+    print("Local model dir:", local_model_dir, "contains:", os.listdir(local_model_dir))
+
+    # Try to fetch feature_order.json from RUN
+    feature_order = None
+    try:
+        p = mlflow.artifacts.download_artifacts(f"runs:/{mv.run_id}/feature_order.json", dst_path=td)
+        with open(p, "r") as f:
+            feature_order = json.load(f)
+        print(f"Loaded feature_order.json with {len(feature_order)} columns")
+    except Exception as e:
+        print("No feature_order.json — proceeding with DF column order. Reason:", e)
+
+    # ----- Load model (XGBoost → PyFunc) -----
+    try:
+        from mlflow import xgboost as mlf_xgb
+        model = mlf_xgb.load_model(local_model_dir)
+        flavor = "xgboost"
+        print("✅ Loaded XGBoost flavor")
+    except Exception as e1:
+        print("XGBoost failed:", e1, "→ trying PyFunc")
+        model = mlflow.pyfunc.load_model(local_model_dir)
+        flavor = "pyfunc"
+        print("✅ Loaded PyFunc flavor")
+
+    # ----- Build features on a sample row and predict -----
+    from mlops_fraud.features import build_features
+
+    sample = pd.DataFrame([{
+        "type": "PAYMENT",
+        "amount": 123.45,
+        "step": 1,
+        "oldbalanceOrg": 1000.0,
+        "newbalanceOrig": 876.55,
+        "oldbalanceDest": 500.0,
+        "newbalanceDest": 623.45,
+    }])
+    X = build_features(sample, for_inference=True)
+    if feature_order:
+        X = X.reindex(columns=feature_order, fill_value=0)
+
+    if flavor == "xgboost" and hasattr(model, "predict_proba"):
+        proba = model.predict_proba(X)
+        score = float(np.asarray(proba)[:, 1][0])
+    else:
+        y = np.asarray(model.predict(X))
+        if y.ndim == 2 and y.shape[1] == 2:
+            y = y[:, 1]
+        score = float(y.ravel()[0])
+
+    print("\n=== SMOKE PREDICTION ===")
+    print("flavor      :", flavor)
+    print("model_ref   :", f"models:/{MODEL_NAME}/{mv.version}")
+    print("score       :", score)

--- a/scripts/smoke_registry.py
+++ b/scripts/smoke_registry.py
@@ -1,0 +1,65 @@
+import os, tempfile, re
+import mlflow
+from mlflow.tracking import MlflowClient
+import boto3
+
+BUCKET_ROOT = os.getenv("ARTIFACTS_URI", "").rstrip("/")
+assert BUCKET_ROOT.startswith("s3://"), "ARTIFACTS_URI must be s3://... (no trailing slash)"
+bucket = BUCKET_ROOT.split("://",1)[1].split("/",1)[0]
+prefix_base = "/".join(BUCKET_ROOT.split("/",3)[3:])  # '' or existing prefix
+if prefix_base: prefix_base += "/"
+
+mlflow.set_tracking_uri(os.getenv("MLFLOW_TRACKING_URI","http://mlflow:5000"))
+name = os.getenv("MODEL_NAME","fraud_xgb"); alias = os.getenv("MODEL_ALIAS","staging")
+c = MlflowClient()
+mv = c.get_model_version_by_alias(name, alias)
+print(f"Resolved {name}@{alias} -> v{mv.version}, run_id={mv.run_id}")
+print("mv.source:", mv.source)
+
+region = os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION")
+s3 = boto3.client("s3", region_name=region)
+
+# find the registry directory that contains this version’s model
+# we look under artifacts/fraud_train/models/**/artifacts/ and pick the newest folder that has MLmodel
+scan_prefix = f"{prefix_base}artifacts/fraud_train/models/"
+resp = s3.list_objects_v2(Bucket=bucket, Prefix=scan_prefix, Delimiter="/")
+# paginate through subfolders
+folders = set()
+while True:
+    for cp in resp.get("CommonPrefixes", []):
+        folders.add(cp["Prefix"])
+    if resp.get("IsTruncated"):
+        resp = s3.list_objects_v2(Bucket=bucket, Prefix=scan_prefix, Delimiter="/",
+                                  ContinuationToken=resp["NextContinuationToken"])
+    else:
+        break
+
+candidates = []
+for f in sorted(folders):
+    # look for MLmodel under <folder>/artifacts/
+    mlmodel_key = f + "artifacts/MLmodel"
+    head = s3.list_objects_v2(Bucket=bucket, Prefix=mlmodel_key, MaxKeys=1)
+    if head.get("KeyCount"):
+        candidates.append(f)
+
+if not candidates:
+    raise SystemExit("No registry folders with MLmodel found under " + scan_prefix)
+
+chosen = sorted(candidates)[-1]  # pick the newest by path (works if m-ids are time-based)
+s3_model_dir = "s3://"+bucket+"/"+chosen+"artifacts"
+print("Chosen registry path:", s3_model_dir)
+
+with tempfile.TemporaryDirectory() as td:
+    local_dir = mlflow.artifacts.download_artifacts(s3_model_dir, dst_path=td)
+    import os as _os
+    print("Downloaded files:", _os.listdir(local_dir))
+    try:
+        from mlflow import xgboost as mlf_xgb
+        _ = mlf_xgb.load_model(local_dir)
+        print("✅ Loaded XGBoost flavor")
+    except Exception as e1:
+        print("XGB failed:", e1, "→ trying PyFunc")
+        _ = mlflow.pyfunc.load_model(local_dir)
+        print("✅ Loaded PyFunc flavor")
+
+print("SMOKE REGISTRY DIRECT: OK")

--- a/src/mlops_fraud/deployment/api.py
+++ b/src/mlops_fraud/deployment/api.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+import os, json, time, logging, threading, shutil, tempfile
+from typing import List, Dict, Any, Optional, Tuple
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeout
+
+import numpy as np
+import pandas as pd
+import boto3
+import mlflow
+from mlflow.tracking import MlflowClient
+from mlflow import xgboost as mlf_xgb
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from mlops_fraud.features import build_features
+
+# ---------- Logging ----------
+LOG = logging.getLogger("uvicorn")
+LOG.setLevel(logging.INFO)
+
+# ---------- Config ----------
+TRACKING       = os.getenv("MLFLOW_TRACKING_URI", "http://localhost:5500")
+MODEL_NAME     = os.getenv("MODEL_NAME", "fraud_xgb")
+MODEL_ALIAS    = os.getenv("MODEL_ALIAS", "staging")
+MODEL_STAGE    = os.getenv("MODEL_STAGE", "")
+MODEL_VERSION  = os.getenv("MODEL_VERSION", "")
+REFRESH_SECS   = int(os.getenv("MODEL_REFRESH_SECS", "120"))
+READY_TIMEOUT  = int(os.getenv("MODEL_READY_TIMEOUT_SECS", "10"))
+HTTP_TIMEOUT   = int(os.getenv("MLFLOW_HTTP_REQUEST_TIMEOUT", "30"))
+ARTIFACTS_URI  = os.getenv("ARTIFACTS_URI", "").rstrip("/")  # e.g. s3://mlops-fraud-dvc
+AWS_REGION     = os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION")
+
+mlflow.set_tracking_uri(TRACKING)
+client = MlflowClient()
+app = FastAPI(title="Fraud XGB Inference", version="1.0")
+
+# ---------- Schemas ----------
+class PredictRequest(BaseModel):
+    rows: List[Dict[str, Any]] = Field(..., min_length=1, description="List of input rows")
+
+class PredictResponse(BaseModel):
+    scores: List[float]
+    n: int
+    model_ref: str
+
+# ---------- Globals ----------
+_model_xgb = None
+_model_pyfunc = None
+_feature_order: Optional[list] = None
+_last_loaded_ts = 0.0
+_last_source = ""
+_artifacts_dir: Optional[str] = None  # persistent temp folder for loaded model
+_lock = threading.RLock()
+
+REQUIRED_MIN_COLS = [
+    "type", "amount", "step",
+    "oldbalanceOrg", "newbalanceOrig",
+    "oldbalanceDest", "newbalanceDest",
+]
+
+# ---------- Helpers ----------
+def _resolve_model_uri_and_runid() -> Tuple[str, Optional[str], str]:
+    """
+    Returns (models:/name/version, run_id, version_str).
+    Always resolves to a numeric version (never alias/stage in the URI).
+    """
+    LOG.info(f"Resolving model → name={MODEL_NAME}, alias={MODEL_ALIAS}, stage={MODEL_STAGE}, version={MODEL_VERSION}")
+
+    # 1) Alias
+    if MODEL_ALIAS:
+        try:
+            mv = client.get_model_version_by_alias(MODEL_NAME, MODEL_ALIAS)
+            return f"models:/{MODEL_NAME}/{mv.version}", mv.run_id, str(mv.version)
+        except Exception as e:
+            LOG.warning(f"Alias resolution failed: {e}")
+
+    # 2) Stage
+    if MODEL_STAGE:
+        try:
+            mvs = client.search_model_versions(f"name='{MODEL_NAME}'")
+            staged = [mv for mv in mvs if mv.current_stage and mv.current_stage.lower() == MODEL_STAGE.lower()]
+            if staged:
+                mv = max(staged, key=lambda m: int(m.version))
+                return f"models:/{MODEL_NAME}/{mv.version}", mv.run_id, str(mv.version)
+            LOG.warning(f"No versions found at stage={MODEL_STAGE}")
+        except Exception as e:
+            LOG.warning(f"Stage resolution failed: {e}")
+
+    # 3) Explicit version
+    if MODEL_VERSION:
+        try:
+            mv = client.get_model_version(MODEL_NAME, MODEL_VERSION)
+            return f"models:/{MODEL_NAME}/{mv.version}", mv.run_id, str(mv.version)
+        except Exception as e:
+            LOG.warning(f"Version resolution failed: {e}")
+
+    # 4) Latest version
+    mvs = client.search_model_versions(f"name='{MODEL_NAME}'")
+    if not mvs:
+        raise RuntimeError(f"No registered versions found for model '{MODEL_NAME}'")
+    mv = max(mvs, key=lambda m: int(m.version))
+    return f"models:/{MODEL_NAME}/{mv.version}", mv.run_id, str(mv.version)
+
+def _experiment_name_for_run(run_id: str) -> str:
+    run = client.get_run(run_id)
+    exp = client.get_experiment(run.info.experiment_id)
+    return exp.name
+
+def _discover_registry_s3_dir(run_id: str) -> str:
+    """
+    Locate: s3://<bucket>/<optional-prefix>/artifacts/<experiment_name>/models/m-*/artifacts
+    Pick latest folder that contains 'MLmodel'.
+    """
+    if not (ARTIFACTS_URI.startswith("s3://") and AWS_REGION):
+        raise RuntimeError("ARTIFACTS_URI must be s3://… and AWS_REGION/DEFAULT_REGION must be set")
+
+    _, rest = ARTIFACTS_URI.split("s3://", 1)
+    bucket, *prefix = rest.split("/", 1)
+    base_prefix = (prefix[0] + "/") if prefix else ""
+
+    exp_name = _experiment_name_for_run(run_id)
+    models_prefix = f"{base_prefix}artifacts/{exp_name}/models/"
+
+    s3 = boto3.client("s3", region_name=AWS_REGION)
+    paginator = s3.get_paginator("list_objects_v2")
+
+    newest_key = None
+    newest_time = None
+    for page in paginator.paginate(Bucket=bucket, Prefix=models_prefix):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            if key.endswith("artifacts/MLmodel"):
+                lm = obj["LastModified"]
+                if newest_time is None or lm > newest_time:
+                    newest_time = lm
+                    newest_key = key
+
+    if not newest_key:
+        raise RuntimeError(f"No registry MLmodel found under s3://{bucket}/{models_prefix}")
+
+    return "s3://" + bucket + "/" + newest_key.rsplit("/", 1)[0]  # .../artifacts
+
+def _download_models_uri_with_timeout(uri: str, dst_dir: str) -> str:
+    """Download artifacts for models:/... into dst_dir with a timeout; returns dst_dir."""
+    def _work():
+        return mlflow.artifacts.download_artifacts(uri, dst_path=dst_dir)
+    with ThreadPoolExecutor(max_workers=1) as ex:
+        fut = ex.submit(_work)
+        fut.result(timeout=HTTP_TIMEOUT)
+    return dst_dir
+
+def _prepare_clean_dir() -> str:
+    global _artifacts_dir
+    # remove previous staged dir
+    if _artifacts_dir and os.path.isdir(_artifacts_dir):
+        shutil.rmtree(_artifacts_dir, ignore_errors=True)
+    _artifacts_dir = tempfile.mkdtemp(prefix="model_artifacts_")
+    return _artifacts_dir
+
+def _download_feature_order(run_id: str) -> Optional[list]:
+    if not run_id:
+        return None
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            p = mlflow.artifacts.download_artifacts(f"runs:/{run_id}/feature_order.json", dst_path=td)
+            with open(p, "r") as f:
+                return json.load(f)
+    except Exception as e:
+        LOG.warning(f"No feature_order.json (run={run_id}): {e}")
+        return None
+
+# ---------- Loader ----------
+def _load_model(force: bool = False):
+    global _model_xgb, _model_pyfunc, _feature_order, _last_loaded_ts, _last_source
+    with _lock:
+        if not force and (time.time() - _last_loaded_ts) < REFRESH_SECS and (_model_xgb or _model_pyfunc):
+            return
+
+        uri, run_id, version_str = _resolve_model_uri_and_runid()
+        _last_source = uri
+
+        # Honor SKIP_REGISTRY_RESOLVER (or fallback only if resolver fails)
+        use_direct = os.getenv("SKIP_REGISTRY_RESOLVER", "0") == "1"
+        local_dir = _prepare_clean_dir()
+
+        if use_direct:
+            # ---- DIRECT S3 (fast path) ----
+            LOG.info("SKIP_REGISTRY_RESOLVER=1 → loading directly from registry S3")
+            s3_dir = _discover_registry_s3_dir(run_id)
+            LOG.info("Discovered registry S3 dir: %s", s3_dir)
+            local_dir = mlflow.artifacts.download_artifacts(s3_dir, dst_path=local_dir)
+            LOG.info("Downloaded registry artifacts to %s", local_dir)
+        else:
+            # ---- TRY REGISTRY RESOLVER, THEN FALL BACK ----
+            LOG.info("Loading model via registry resolver: %s (timeout=%ss)", uri, HTTP_TIMEOUT)
+            try:
+                _download_models_uri_with_timeout(uri, local_dir)
+                LOG.info("Downloaded registry artifacts to %s", local_dir)
+            except FuturesTimeout:
+                LOG.warning("Timed out downloading %s; falling back to direct S3 registry discovery", uri)
+                shutil.rmtree(local_dir, ignore_errors=True)
+                local_dir = _prepare_clean_dir()
+            except Exception as e:
+                LOG.warning("Registry download failed (%s); falling back to direct S3 registry discovery", e)
+                shutil.rmtree(local_dir, ignore_errors=True)
+                local_dir = _prepare_clean_dir()
+
+            if not os.listdir(local_dir):
+                s3_dir = _discover_registry_s3_dir(run_id)
+                LOG.info("Discovered registry S3 dir: %s", s3_dir)
+                local_dir = mlflow.artifacts.download_artifacts(s3_dir, dst_path=local_dir)
+                LOG.info("Downloaded registry artifacts to %s", local_dir)
+
+        # ---- Load model from local_dir ----
+        try:
+            _model_xgb = mlf_xgb.load_model(local_dir)
+            _model_pyfunc = None
+            LOG.info("Loaded XGBoost flavor from local dir")
+        except Exception as e1:
+            LOG.warning("XGBoost load failed: %s; trying PyFunc", e1)
+            _model_xgb = None
+            _model_pyfunc = mlflow.pyfunc.load_model(local_dir)
+            LOG.info("Loaded PyFunc flavor from local dir")
+
+        # ---- Feature order from RUN ----
+        _feature_order = _download_feature_order(run_id) if run_id else None
+        if _feature_order:
+            LOG.info("Loaded feature_order.json (%d features)", len(_feature_order))
+        else:
+            LOG.info("feature_order.json not found; using dataframe column order")
+
+        _last_loaded_ts = time.time()
+
+
+# ---------- Scoring ----------
+def _score(df: pd.DataFrame) -> pd.Series:
+    X = build_features(df, for_inference=True)
+    if _feature_order:
+        X = X.reindex(columns=_feature_order, fill_value=0)
+    if _model_xgb is not None:
+        proba = _model_xgb.predict_proba(X)
+        return pd.Series(np.asarray(proba)[:, 1].ravel(), index=X.index)
+    y = np.asarray(_model_pyfunc.predict(X))
+    if y.ndim == 2 and y.shape[1] == 2:
+        y = y[:, 1]
+    return pd.Series(y.ravel(), index=X.index)
+
+# ---------- Lifecycle ----------
+def _warmup():
+    try:
+        _load_model(force=True)
+    except Exception as e:
+        LOG.warning("Warmup load failed: %s", e)
+
+@app.on_event("startup")
+def startup():
+    threading.Thread(target=_warmup, daemon=True).start()
+
+# ---------- Endpoints ----------
+@app.get("/healthz")
+def healthz():
+    status = "ready" if (_model_xgb or _model_pyfunc) else "starting"
+    return {"status": status, "model_ref": _last_source, "last_loaded_ts": _last_loaded_ts}
+
+def _try_load_with_timeout(seconds: int):
+    with ThreadPoolExecutor(max_workers=1) as ex:
+        fut = ex.submit(_load_model, True)
+        return fut.result(timeout=seconds)
+
+@app.get("/readyz")
+def readyz():
+    # if already loaded, don't poke the network
+    if _model_xgb or _model_pyfunc:
+        return {"status": "ready", "model_ref": _last_source}
+    try:
+        # prefer direct S3 to keep this quick
+        with ThreadPoolExecutor(max_workers=1) as ex:
+            fut = ex.submit(_load_model, True)  # SKIP_REGISTRY_RESOLVER=1 handles direct path
+            fut.result(timeout=READY_TIMEOUT)
+        return {"status": "ready", "model_ref": _last_source}
+    except FuturesTimeout:
+        return {"status": "loading-timeout", "model_ref": _last_source}
+    except Exception as e:
+        return {"status": "error", "detail": str(e), "model_ref": _last_source}
+
+@app.post("/predict", response_model=PredictResponse)
+def predict(req: PredictRequest):
+    try:
+        if not (_model_xgb or _model_pyfunc):
+            _load_model(force=True)
+        if not (_model_xgb or _model_pyfunc):
+            raise HTTPException(status_code=503, detail="Model not ready")
+
+        df = pd.DataFrame(req.rows)
+        missing = [c for c in REQUIRED_MIN_COLS if c not in df.columns]
+        if missing:
+            raise HTTPException(status_code=400, detail=f"Missing required columns: {missing}")
+
+        scores = _score(df)
+        return PredictResponse(scores=scores.tolist(), n=len(scores), model_ref=_last_source)
+    except HTTPException:
+        raise
+    except Exception as e:
+        LOG.error("Prediction failed", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Prediction failed: {e}")
+
+@app.post("/reload")
+def reload_model():
+    _load_model(force=True)
+    return {"status": "reloaded", "model_ref": _last_source}


### PR DESCRIPTION
##  FastAPI Model Serving Integration

### Overview
This PR introduces the initial FastAPI-based inference API for serving the XGBoost fraud detection model through MLflow registry and S3 artifacts. It also adds the necessary Docker/Compose setup for containerized deployment.

### 🔑 Changes
- **compose.yaml**
  - Added `api` service (FastAPI) depending on MLflow server
  - Exposed API on port `8080`
  - Set env vars for model resolution (`MODEL_NAME`, `MODEL_ALIAS`, `SKIP_REGISTRY_RESOLVER`, etc.)

- **Dockerfile.api**
  - New Dockerfile for building and running the FastAPI inference API

- **src/mlops_fraud/deployment/api.py**
  - Core FastAPI app with:
    - `/healthz` and `/readyz` endpoints
    - `/predict` endpoint for fraud scoring
    - Model loading via MLflow registry or direct S3
    - Automatic refresh/reload with feature order handling

### 🧪 Debug Scripts
- Created several smoke/debug scripts during troubleshooting (`scripts/smoke_*.py`, `debug_mlflow.py`, `debug_model_path.py`, etc.)
- Proposal: keep only the `scripts/smoke_*.py` inside `scripts/` (they’re useful for regression/debug testing), and drop the rest.

### ✅ Next Steps
- Decide whether to include smoke scripts in repo or `.gitignore` them
- Add tests (`test_api.py`, `test_load_model.py`) once serving path is stable
- Wire up CI to run smoke predictions after container build

---

Closes #<issue-id-if-any>
