### PR TITLE
feat(api): strict input contract + helpful 422s + Prometheus metrics

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 COPY src /app/src
 
 RUN pip install --no-cache-dir \
-    mlflow==3.1.4 fastapi uvicorn[standard] pandas numpy scikit-learn xgboost pydantic boto3
+    mlflow==3.1.4 fastapi uvicorn[standard] pandas numpy scikit-learn xgboost pydantic boto3 prometheus-client 
 
 ENV PYTHONPATH=/app/src
 ENV MLFLOW_TRACKING_URI=http://mlflow:5000

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ apache-airflow	# DAG-based orchestration
 # === Serving (FastAPI backend) ===
 fastapi		# API for model inference
 uvicorn		# ASGI server to run FastAPI
+prometheus-client   # Expose API metrics (/metrics) for Prometheus scraping
 
 # === Visualization ===
 matplotlib	# Basic plots

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -1,0 +1,25 @@
+#tests/test_api_contract.py
+from fastapi.testclient import TestClient
+from mlops_fraud.deployment.api import app
+
+client = TestClient(app)
+
+def test_rejects_unknown_field():
+    bad = {
+        "rows": [{
+            "type": "PAYMENT",
+            "amount": 10,
+            "step": 1,
+            "oldbalanceOrg": 100,
+            "newbalanceOrig": 90,
+            "oldbalanceDest": 50,
+            "newbalanceDest": 60,
+            "UNKNOWN": "boom"          # should be rejected
+        }]
+    }
+    r = client.post("/predict", json=bad)
+    assert r.status_code == 422
+    body = r.json()
+    assert body["error"] == "Invalid request"
+    # Pydantic reports path to offending field
+    assert any("UNKNOWN" in str(item["loc"]) for item in body["detail"])

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,3 +1,4 @@
+# tests/test_features.py
 import numpy as np
 import pandas as pd
 from mlops_fraud.features import build_features, prepare_training, TYPE_CATS

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,3 +1,4 @@
+# tests/test_schemas.py
 import importlib
 import pandas as pd
 import pytest


### PR DESCRIPTION
## feat(api): strict input contract + helpful 422s + Prometheus metrics**

### Changes
- Enforce strict request schema with Pydantic v2 (`extra="forbid"`).
- Custom 422 handler: `{ "error": "Invalid request", "detail": [...] }`.
- Middleware logs per-request timing; expose `/metrics` (Prometheus counters + latency histogram).
- Add `prometheus-client` to image/requirements.

### Files
- `src/mlops_fraud/deployment/api.py`
- `requirements.txt` (+ `prometheus-client`)
- `Dockerfile.api` (installs `prometheus-client`)
- `tests/test_api_contract.py` 

### Why
- Prevent schema drift; reject unexpected fields early.
- Actionable error messages.
- Basic observability (RPS + latency).

### Verify
```sh
docker compose build api && docker compose up -d api
curl -sS http://localhost:8080/healthz
curl -sS http://localhost:8080/metrics | head
# Unknown field -> 422
curl -sS -o /dev/null -w "%{http_code}\n" \
  -X POST http://localhost:8080/predict -H 'content-type: application/json' \
  -d '{"rows":[{"type":"PAYMENT","amount":10,"step":1,"oldbalanceOrg":1,"newbalanceOrig":1,"oldbalanceDest":1,"newbalanceDest":1,"EXTRA":1}]}'
````

### Tests

* `tests/test_api_contract.py`: asserts 422 on unknown field.

```sh
pip install -e . && pytest -q tests/test_api_contract.py
```
